### PR TITLE
FEAT: 게시글 포스트 무한 스크롤 구현 

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -28,6 +28,7 @@
     "framer-motion": "^11.3.28",
     "lottie-web": "^5.12.2",
     "lucide-react": "^0.429.0",
+    "nanoid": "^5.0.9",
     "next": "14.2.5",
     "next-nprogress-bar": "^2.3.13",
     "next-themes": "^0.3.0",

--- a/apps/blog/src/app/_components/PostSection.tsx
+++ b/apps/blog/src/app/_components/PostSection.tsx
@@ -3,16 +3,19 @@
 import { TextGrid } from '@repo/ui/TextGrid';
 import PostList from './PostList';
 import { wrap } from '@suspensive/react';
-import { SuspenseQuery } from '@suspensive/react-query';
+import { SuspenseInfiniteQuery } from '@suspensive/react-query';
 import { PostQueryOptions } from '@/hooks/post';
 import type { NotionPage } from '@/models/notion';
+import { nanoid } from 'nanoid';
 
 const PostSection = wrap.Suspense().on(() => (
   <section className={'flex flex-col gap-4'}>
     <TextGrid title={'최근 포스트'} description={'여러 이야기를 다루고 있어요 🤗'} />
-    <SuspenseQuery {...PostQueryOptions.getPosts({})}>
-      {({ data: { results } }) => results && <PostList posts={results as NotionPage[]} />}
-    </SuspenseQuery>
+    <SuspenseInfiniteQuery {...PostQueryOptions.getInfinitePosts({})}>
+      {({ data }) => {
+        return data.pages.map((page) => <PostList key={nanoid()} posts={page as NotionPage[]} />);
+      }}
+    </SuspenseInfiniteQuery>
   </section>
 ));
 

--- a/apps/blog/src/app/api/posts/route.ts
+++ b/apps/blog/src/app/api/posts/route.ts
@@ -4,8 +4,8 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 function getParameters(params: URLSearchParams) {
   return {
-    page: Number(params.get('page') || 1),
     pageSize: Number(params.get('pageSize') || 5),
+    start_cursor: params.get('start_cursor') || undefined,
     sort: params.get('sort') || ('descending' as 'descending' | 'ascending'),
     sortBy: params.get('sortBy') || ('Date' as 'Date' | 'Likes'),
     search: params.get('search') || '',
@@ -26,6 +26,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const response = await notionClient.getPostsByParams(parameters as GetPostRequest);
+    
     return NextResponse.json(response);
   } catch (error) {
     console.error(error);

--- a/apps/blog/src/app/api/posts/route.ts
+++ b/apps/blog/src/app/api/posts/route.ts
@@ -4,10 +4,10 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 function getParameters(params: URLSearchParams) {
   return {
-    pageSize: Number(params.get('pageSize') || 5),
+    page_size: Number(params.get('page_size') || 5),
     start_cursor: params.get('start_cursor') || undefined,
     sort: params.get('sort') || ('descending' as 'descending' | 'ascending'),
-    sortBy: params.get('sortBy') || ('Date' as 'Date' | 'Likes'),
+    sort_by: params.get('sort_by') || ('Date' as 'Date' | 'Likes'),
     search: params.get('search') || '',
     tag: params.get('tag') || '',
     category: params.get('category') || '',

--- a/apps/blog/src/app/api/tags/route.ts
+++ b/apps/blog/src/app/api/tags/route.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const nextCursor = searchParams.get('nextCursor') ?? undefined;
+  const nextCursor = searchParams.get('next_cursor') ?? undefined;
 
   try {
     const response = await notionClient.getAllTags(nextCursor);

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -15,7 +15,7 @@ export default async function HomePage() {
   return (
     <main className={'flex flex-col mx-auto gap-4 min-h-screen'}>
       <ProfileCard />
-      <QueryHydrationBoundary queryOptions={PostQueryOptions.getPosts({})}>
+      <QueryHydrationBoundary queryOptions={PostQueryOptions.getInfinitePosts({})} isInfiniteQuery={true}>
         <PostSection />
       </QueryHydrationBoundary>
     </main>

--- a/apps/blog/src/app/posts/_components/PostListBody.tsx
+++ b/apps/blog/src/app/posts/_components/PostListBody.tsx
@@ -3,12 +3,14 @@
 import { wrap } from '@suspensive/react';
 import { PostListSkeleton } from '@repo/ui/skeletons/PostListSkeleton';
 import { Typography } from '@repo/ui/ui/typography';
-import { SuspenseQuery } from '@suspensive/react-query';
+import { SuspenseInfiniteQuery } from '@suspensive/react-query';
 import { PostQueryOptions } from '@/hooks/post';
 import PostList from '@/app/_components/PostList';
 import type { NotionPage } from '@/models/notion';
 import { useQueryString } from '@repo/utils/hooks';
-
+import { ChevronDown, Loader2 } from 'lucide-react';
+import { Button } from '@repo/ui/ui/button';
+import { nanoid } from 'nanoid';
 const PostListBody = wrap
   .Suspense({ fallback: <PostListSkeleton /> })
   .ErrorBoundary({
@@ -22,15 +24,15 @@ const PostListBody = wrap
     const { search, tag, category } = useQueryString(['search', 'tag', 'category']);
 
     return (
-      <SuspenseQuery
-        {...PostQueryOptions.getPosts({
+      <SuspenseInfiniteQuery
+        {...PostQueryOptions.getInfinitePosts({
           search,
           tag,
           category,
         })}
       >
-        {(data) => {
-          if (!data.data.results || data.data.results.length === 0) {
+        {({ data, isFetchingNextPage, hasNextPage, fetchNextPage }) => {
+          if (!data.pages) {
             return (
               <div className="flex flex-col items-center justify-center min-h-[200px] gap-4 rounded-lg border border-dashed border-muted p-8">
                 <Typography variant="p" className="text-muted-foreground">
@@ -40,9 +42,35 @@ const PostListBody = wrap
             );
           }
 
-          return <PostList posts={data.data.results as NotionPage[]} />;
+          return (
+            <div>
+              {data.pages.map((page) => (
+                <PostList key={nanoid()} posts={page as NotionPage[]} />
+              ))}
+              {hasNextPage && (
+                <Button
+                  variant="outline"
+                  onClick={() => fetchNextPage()}
+                  className="w-full p-4 mt-8 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors rounded-lg border border-dashed border-muted hover:border-muted-foreground flex items-center justify-center gap-2"
+                  disabled={isFetchingNextPage}
+                >
+                  {isFetchingNextPage ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      불러오고 있어요 🤓
+                    </>
+                  ) : (
+                    <>
+                      <ChevronDown className="w-4 h-4 animate-bounce" />
+                      더 보기 📖
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+          )
         }}
-      </SuspenseQuery>
+      </SuspenseInfiniteQuery>
     );
   });
 

--- a/apps/blog/src/components/QueryHydrationBoundary.tsx
+++ b/apps/blog/src/components/QueryHydrationBoundary.tsx
@@ -4,11 +4,17 @@ interface QueryHydrationBoundaryProps {
   children: React.ReactNode;
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   queryOptions: any;
+  isInfiniteQuery?: boolean;
 }
 
-const QueryHydrationBoundary = async ({ children, queryOptions }: QueryHydrationBoundaryProps) => {
+const QueryHydrationBoundary = async ({ children, queryOptions, isInfiniteQuery }: QueryHydrationBoundaryProps) => {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery(queryOptions);
+
+  if (isInfiniteQuery) {
+    await queryClient.prefetchInfiniteQuery(queryOptions);
+  } else {
+    await queryClient.prefetchQuery(queryOptions);
+  }
 
   const dehydratedState = dehydrate(queryClient);
 

--- a/apps/blog/src/hooks/post/index.ts
+++ b/apps/blog/src/hooks/post/index.ts
@@ -22,17 +22,25 @@ export const PostQueryKeys = {
 };
 
 export const PostQueryOptions = {
-  getPosts: (getPostRequest?: GetPostRequest) =>
-    queryOptions({
+  getInfinitePosts: (getPostRequest?: GetPostRequest) =>
+    infiniteQueryOptions({
       queryKey: PostQueryKeys.getPosts(getPostRequest),
-      queryFn: () => postService.getPosts(getPostRequest),
+      queryFn: ({ pageParam }) => postService.getPosts(getPostRequest, pageParam),
+      getNextPageParam: (lastPage) => lastPage.next_cursor ?? null,
+      initialPageParam: '',
+      select: (response) => {
+        return {
+          pages: response.pages.map((page) => page.results),
+          pageParams: response.pages.map((page) => page.next_cursor),
+        };
+      },
     }),
   getInfiniteTags: () =>
     infiniteQueryOptions({
       queryKey: PostQueryKeys.getTags(),
       queryFn: ({ pageParam }) => postService.getTags(pageParam),
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
-      initialPageParam: undefined,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? null,
+      initialPageParam: '',
       select: (response) => ({
         pages: response.pages.map((page) => page.tags),
         pageParams: response.pages.map((page) => page.nextCursor),

--- a/apps/blog/src/hooks/post/index.ts
+++ b/apps/blog/src/hooks/post/index.ts
@@ -22,8 +22,8 @@ export const PostQueryKeys = {
 };
 
 export const PostQueryOptions = {
-  getInfinitePosts: (getPostRequest?: GetPostRequest) =>
-    infiniteQueryOptions({
+  getInfinitePosts: (getPostRequest?: GetPostRequest) => {
+    return infiniteQueryOptions({
       queryKey: PostQueryKeys.getPosts(getPostRequest),
       queryFn: ({ pageParam }) => postService.getPosts(getPostRequest, pageParam),
       getNextPageParam: (lastPage) => lastPage.next_cursor ?? null,
@@ -34,7 +34,8 @@ export const PostQueryOptions = {
           pageParams: response.pages.map((page) => page.next_cursor),
         };
       },
-    }),
+    });
+  },
   getInfiniteTags: () =>
     infiniteQueryOptions({
       queryKey: PostQueryKeys.getTags(),

--- a/apps/blog/src/lib/notion/notion.ts
+++ b/apps/blog/src/lib/notion/notion.ts
@@ -38,7 +38,7 @@ async function getPosts() {
 }
 
 async function getPostsByParams(params: GetPostRequest) {
-  const { search, tag, category, sortBy = 'Date', sort = 'descending', pageSize = 10, series } = params;
+  const { search, tag, category, sortBy = 'Date', sort = 'descending', pageSize = 10, series, start_cursor } = params;
 
   const baseFilter = {
     property: 'Published',
@@ -70,6 +70,7 @@ async function getPostsByParams(params: GetPostRequest) {
       filter: { and: filters },
       sorts: [{ property: sortBy, direction: sort }],
       page_size: pageSize,
+      start_cursor: start_cursor,
     });
   } catch (error) {
     console.error('getPostsByParams error', error);

--- a/apps/blog/src/lib/notion/notion.ts
+++ b/apps/blog/src/lib/notion/notion.ts
@@ -38,7 +38,7 @@ async function getPosts() {
 }
 
 async function getPostsByParams(params: GetPostRequest) {
-  const { search, tag, category, sortBy = 'Date', sort = 'descending', pageSize = 10, series, start_cursor } = params;
+  const { search, tag, category, sort_by = 'Date', sort = 'descending', page_size = 10, series, start_cursor } = params;
 
   const baseFilter = {
     property: 'Published',
@@ -68,9 +68,9 @@ async function getPostsByParams(params: GetPostRequest) {
     return await notion.databases.query({
       database_id: POST_DATABASE_ID,
       filter: { and: filters },
-      sorts: [{ property: sortBy, direction: sort }],
-      page_size: pageSize,
-      start_cursor: start_cursor,
+      sorts: [{ property: sort_by, direction: sort }],
+      page_size: page_size,
+      start_cursor: start_cursor ? start_cursor : undefined,
     });
   } catch (error) {
     console.error('getPostsByParams error', error);
@@ -267,7 +267,7 @@ async function getAllTags(nextCursor?: string) {
   try {
     const response = await notion.databases.query({
       database_id: POST_DATABASE_ID,
-      start_cursor: nextCursor as string | undefined,
+      start_cursor: nextCursor ? nextCursor : undefined,
       page_size: 3,
       filter: {
         property: 'Tags',

--- a/apps/blog/src/models/post.ts
+++ b/apps/blog/src/models/post.ts
@@ -5,8 +5,8 @@ export interface PostLikeRequest {
   currentLikeCount: number;
 }
 export interface GetPostRequest {
-  page?: number;
   pageSize?: number;
+  start_cursor?: string | undefined;
   sort?: 'ascending' | 'descending';
   sortBy?: MyProperties;
   search?: string;
@@ -17,7 +17,7 @@ export interface GetPostRequest {
 
 export interface GetTagsResponse {
   tags: string[];
-  nextCursor: null | undefined;
+  nextCursor: string | null;
 }
 
 export interface PostLikeResponse {

--- a/apps/blog/src/models/post.ts
+++ b/apps/blog/src/models/post.ts
@@ -5,10 +5,10 @@ export interface PostLikeRequest {
   currentLikeCount: number;
 }
 export interface GetPostRequest {
-  pageSize?: number;
+  page_size?: number;
   start_cursor?: string | undefined;
   sort?: 'ascending' | 'descending';
-  sortBy?: MyProperties;
+  sort_by?: MyProperties;
   search?: string;
   tag?: string;
   category?: string;

--- a/apps/blog/src/services/post/index.ts
+++ b/apps/blog/src/services/post/index.ts
@@ -21,8 +21,8 @@ const getPosts = async (getPostRequest?: GetPostRequest, startCursor: string | u
   return data;
 };
 
-const getTags = async (nextCursor?: string | undefined ) => {
-  const { data } = await axiosClient.get<GetTagsResponse>('/tags', { params: { nextCursor } });
+const getTags = async (nextCursor?: string | undefined) => {
+  const { data } = await axiosClient.get<GetTagsResponse>('/tags', { params: { next_cursor: nextCursor } });
   return data;
 };
 

--- a/apps/blog/src/services/post/index.ts
+++ b/apps/blog/src/services/post/index.ts
@@ -16,12 +16,12 @@ const getPostLike = async (pageId: string) => {
   return data;
 };
 
-const getPosts = async (getPostRequest?: GetPostRequest) => {
-  const { data } = await axiosClient.get<QueryDatabaseResponse>('/posts', { params: getPostRequest });
+const getPosts = async (getPostRequest?: GetPostRequest, startCursor: string | undefined = undefined) => {
+  const { data } = await axiosClient.get<QueryDatabaseResponse>('/posts', { params: { ...getPostRequest, start_cursor: startCursor } });
   return data;
 };
 
-const getTags = async (nextCursor?: string | undefined) => {
+const getTags = async (nextCursor?: string | undefined ) => {
   const { data } = await axiosClient.get<GetTagsResponse>('/tags', { params: { nextCursor } });
   return data;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       lucide-react:
         specifier: ^0.429.0
         version: 0.429.0(react@18.3.1)
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.0.9
       next:
         specifier: 14.2.5
         version: 14.2.5(@babel/core@7.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.8)
@@ -5581,6 +5584,11 @@ packages:
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.0.9:
+    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -12603,7 +12611,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -12627,7 +12635,7 @@ snapshots:
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-core-module: 2.15.1
@@ -12649,7 +12657,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -14465,6 +14473,8 @@ snapshots:
     optional: true
 
   nanoid@3.3.7: {}
+
+  nanoid@5.0.9: {}
 
   natural-compare@1.4.0: {}
 


### PR DESCRIPTION
### 변경 사항 (Changes)
- 게시글 포스트 무한 스크롤 구현
- 메인 페이지 & 포스트 페이지 내에 인피니티 스크롤 쿼리 사용하도록 변경 및 캐싱 적용 

### 미리보기 (Preview)
<!-- 
- 디자인/UI 변경: 스크린샷 첨부
- 새로운 기능: 동작 GIF/영상 첨부
- 문서 수정: 변경된 내용 요약
-->

### 테스트 (Test)
<!-- 테스트 방법 또는 테스트 완료 사항을 체크리스트로 작성해주세요 -->
- [x] 로컬 환경에서 테스트 완료
- [ ] 브라우저 호환성 확인 (Chrome, Safari, Firefox 등)

### 참고 사항 (Notes)
<!-- 리뷰어가 알아야 할 내용이나 관련 이슈 번호를 작성해주세요 -->
